### PR TITLE
PHP8.3 compatibility

### DIFF
--- a/src/plugins/system/restrictedfs/src/Extension/RestrictedFS.php
+++ b/src/plugins/system/restrictedfs/src/Extension/RestrictedFS.php
@@ -70,7 +70,7 @@ final class RestrictedFS extends CMSPlugin implements ProviderInterface, Subscri
     // Disable all the filesystem adapters except this one
     $original = (new \ReflectionClass('\Joomla\CMS\Plugin\PluginHelper'))->getProperty('plugins');
     $original->setAccessible(true);
-    $original->setValue(array_filter(
+    $original->setValue(null, array_filter(
       $original->getValue(),
       function ($plugin) {
         if (isset($plugin->type) && $plugin->type !== 'filesystem') return false;


### PR DESCRIPTION
- As of PHP 8.3.0, calling this method with a single argument is deprecated, use ReflectionClass::setStaticPropertyValue() instead.

https://www.php.net/manual/en/reflectionproperty.setvalue.php